### PR TITLE
Fix: remove substituted ftype proclamation

### DIFF
--- a/src/write.lisp
+++ b/src/write.lisp
@@ -2,7 +2,6 @@
 
 
 (declaim (inline make-newline-strine)
-         (ftype (function (t t t stream) t) print-json-key-value)
          (ftype (function (string stream) string) write-json-string))
 
 


### PR DESCRIPTION
Avoid SBCL style-warning:
Generic function `print-json-key-value` clobbers earlier `ftype` proclamation `(function (t t t stream) *)` for the same name with `(function (t t t t) *)`.